### PR TITLE
Expt/Adjust for rating chance when displaying long_term_transitions

### DIFF
--- a/analysis.ipynb
+++ b/analysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -48,7 +48,9 @@
       "\n",
       "\n",
       "review_rating_chance\n",
-      "Long term transition:\n",
+      "Long term transition deviation:\n",
+      "Displays the average difference between users general chances of using a given rating,\n",
+      "and the chances of a rating dependant on the previous rating.\n",
       "(row = previous rating, column = next rating)\n",
       "    |    1       2       3       4   \n",
       "----+--------------------------------\n",
@@ -177,7 +179,9 @@
     "    transition_matrix = np.zeros((4, 4))\n",
     "    for i in range(len(long_term_transition_adjusted)):\n",
     "        transition_matrix[i] = long_term_transition_adjusted[i]\n",
-    "    print(f\"Long term transition:\")\n",
+    "    print(f\"Long term transition deviation:\")\n",
+    "    print(f\"Displays the average difference between users general chances of using a given rating,\\n\"\n",
+    "           \"and the chances of a rating dependant on the previous rating.\")\n",
     "    print_transition_matrix(transition_matrix)\n",
     "\n",
     "    state_rating_costs = np.array([x[\"state_rating_costs\"] for x in data])\n",


### PR DESCRIPTION
Subtracts the average button use of the user from the results displayed. the intention is "the user will press hard x% **more than usual** after pressing the specified previous button"

```
    |    1       2       3       4   
----+--------------------------------
 1  | 0.0454  -0.0055  -0.0304  -0.0205
 2  | 0.0073  0.1187  -0.1051  -0.0459
 3  | -0.0389  -0.0280  0.0858  -0.0267
 4  | -0.0799  -0.0776  -0.0627  0.1405

